### PR TITLE
REF-5674] WIP, package name + version

### DIFF
--- a/components/Python/RestModelServing/restful_h2o_serving_source/client_test.sh
+++ b/components/Python/RestModelServing/restful_h2o_serving_source/client_test.sh
@@ -3,6 +3,6 @@
 script_name=$(basename ${BASH_SOURCE[0]})
 script_dir=$(realpath $(dirname ${BASH_SOURCE[0]}))
 
-PYTHONPATH="../:$HOME/dev/reflex/sub/reflex-algos/target/mlcomp-1.0.2-py2.7.egg:$HOME/dev/reflex/sub/reflex-algos/target/parallelm-1.0.1-py2.7.egg"
+PYTHONPATH="../:$HOME/dev/reflex/sub/reflex-algos/target/mlcomp-py2.egg:$HOME/dev/reflex/sub/reflex-algos/target/mlops-py2.egg"
 
 PYTHONPATH=$PYTHONPATH python h2o_restful_serving.py 8888 $script_dir/model/GBM_model_python_1542317998658_5.zip


### PR DESCRIPTION
This patch is a part of similar patches across reflex/algos/common/mlhub/eco repos.

It unifies naming for mlops/mlcomp/deputy/.
Now, as a result of build will be produced:
actual egg files with the naming like: ml_ops-1.2.3-py3.4.egg and ml_ops-py3.egg which is a symlink pointing to the proper egg file.
These links should be used as actual pointers to the mlops/mlcoms/deputy components.
So the symlinks are:
ml_ops-py2.egg
ml_ops-py3.egg
ml_comp-py2.egg
ml_comp-py3.egg
deputy-py2.egg
deputy-py3.egg

Testing:

local mode - OK
building mcenter dockers - OK
running mcenter - to be tested.