### PR TITLE
[REF-5927] fixed s3 component for engineType rename Generic

### DIFF
--- a/components/Python/Scikit-learn/sink/s3_file_sink/component.json
+++ b/components/Python/Scikit-learn/sink/s3_file_sink/component.json
@@ -1,5 +1,5 @@
 {
-  "engineType": "Python",
+  "engineType": "Generic",
   "userStandalone": false,
   "language": "Python",
   "name": "s3_file_sink",

--- a/components/Python/Scikit-learn/source/s3_file_source/component.json
+++ b/components/Python/Scikit-learn/source/s3_file_source/component.json
@@ -1,5 +1,5 @@
 {
-  "engineType": "Python",
+  "engineType": "Generic",
   "userStandalone": false,
   "language": "Python",
   "name": "s3_file_source",


### PR DESCRIPTION
changes S3 components to use the engineType "Generic" as "Python" is now deprecated on master/v1.4

changes have been validated