### PR TITLE
[REF-6034] MultiClass SVC: Output  Balanced Accuracy Scoree

### DIFF
--- a/components/Python/Scikit-learn/svc-train/svc_train.py
+++ b/components/Python/Scikit-learn/svc-train/svc_train.py
@@ -194,6 +194,33 @@ def main():
     #################### End: Output AUC ####################
     ##############################################################
 
+    #########################################################################
+    #################### Start: Output Balanced Accuracy ####################
+    #########################################################################
+
+    bas = sklearn.metrics.balanced_accuracy_score(labels, labels_pred)
+
+    #################### OLD WAY ####################
+    # First Way
+    #
+    # # Output bas of the chosen model using MCenter
+    # mlops.set_stat("User Defined: Balanced Accuracy Score", bas)
+    #################### DONE OLD WAY ####################
+
+    #################### NEW WAY ####################
+    # Second Way
+    mlops.set_stat(ClassificationMetrics.BALANCED_ACCURACY_SCORE, data=bas)
+
+    # OR
+
+    # Third Way
+    mlops.metrics.balanced_accuracy_score(y_true=labels, y_pred=labels_pred)
+    #################### DONE NEW WAY ####################
+
+    #######################################################################
+    #################### End: Output Balanced Accuracy ####################
+    #######################################################################
+
     ########################################################################
     #################### Start: Output Confusion Matrix ####################
     ########################################################################


### PR DESCRIPTION
- Outputting Stat Using,

  	mlops.set_stat(ClassificationMetrics.BALANCED_ACCURACY_SCORE, bas)

        	OR

    	mlops.metrics.balanced_accuracy_score(y_true=labels_actual, y_pred=labels_pred)