### PR TITLE
Add zero check for a value

### DIFF
--- a/components/Python/RestModelServing/restful_sklearn_serving/sklearn_restful_serving.py
+++ b/components/Python/RestModelServing/restful_sklearn_serving/sklearn_restful_serving.py
@@ -218,7 +218,8 @@ class SklearnRESTfulServing(RESTfulComponent):
                                        .format(pred_probs,  pred_index, prediction, prediction_confidence))
 
                     # Total confidence
-                    self._total_confidence_metric.increase(prediction_confidence)
+                    if self._total_confidence_metric:
+                        self._total_confidence_metric.increase(prediction_confidence)
 
                     if self._num_predictable_classes:
                         # Prediction confidence per class


### PR DESCRIPTION
When running sklearn restful serving as standalone component
_total_confidence_metric is None object, as it is not configured with
the configure() which is called from deputy.